### PR TITLE
Use modern todolist API, use things.py instead of pythings

### DIFF
--- a/.tothingist
+++ b/.tothingist
@@ -5,3 +5,5 @@ api_token: f00f00f00f00f00f00f
 [config]
 statefile: ~/.tothingist_state
 thingslocation: Today
+# Optional - specify a things database. Usually not required
+#thingsdb: ~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-XXXXXX/Things Database.thingsdatabase/main.sqlite

--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ The script can currently sync the Todoist inbox to a list in Things,
 and a Things list to the Todoist inbox. The completed/cancelled
 attributes of both systems are synced back and forth. Changes to
 the content of existing todo objects are not mirrored.
+
+toThingist talks to Todoist API v1 via the official
+[todoist-api-python](https://github.com/Doist/todoist-api-python)
+SDK. Due to constraints in the ToDoist API, *completed todos older
+than 90 days will not be completed in Things*. This is a limitation of
+the API and not something that can be addressed programatically, so
+ensure that your crons run regularly.
+
+toThingist is not backwards compatible with older versions that used
+the older todoist API which no longer works. Having an old state file
+could result in the recreation of old todos, referening of them or
+other messes. toThingist does its best to avoid operating on an old
+state file, but be warned.
+
+Pass ```--dry-run``` (```-n```) to see what a sync would do without
+touching Todoist, Things or the state file.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Bidirectional sync between [Things](http://culturedcode.com/things/) and [ToDois
 
 Requirements
 ---------
-toThingist requires the [pythings](https://github.com/nosmo/pythings) module.
+toThingist requires Python 3 and the
+[pythings](https://github.com/nosmo/pythings) module. Remaining
+dependencies are listed in ```requirements.txt```.
 
 Operation
 ---------

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Bidirectional sync between [Things](http://culturedcode.com/things/) and [ToDois
 
 Requirements
 ---------
-toThingist requires Python 3 and the
-[pythings](https://github.com/nosmo/pythings) module. Remaining
-dependencies are listed in ```requirements.txt```.
+toThingist requires Python 3 and macOS with Things installed.
+Dependencies are listed in ```pyproject.toml```.
 
 Operation
 ---------
@@ -21,8 +20,20 @@ between todoist IDs and things IDs. Use of the state file is not
 required but not using it will result in duplication of imported todos
 so you should probably use it.
 
+Writing to Things requires the use of the Things URL scheme. See the
+[official Things
+documentation](https://culturedcode.com/things/support/articles/2803573/#overview-authorization)
+for details on how to enable its use.
+
 The ```thingslocation``` option is used to indicate where a todo
-should go once imported from todoist. (ie "Today", "Inbox" etc)
+should go once imported from todoist. This can be one of the built-in
+Things lists (```Inbox```, ```Today```, ```Anytime```, ```Someday```)
+or the title of a project or area. Don't use ```Upcoming``` as this
+can't be written to in normal situations
+
+The optional ```thingsdb``` option points at the Things database. This
+isn't generally required as thingsapi can find it in most cases. The
+`THINGSDB` environment variable can also be set.
 
 Running toThingist.py will sync all todos in ```thingslocation``` to
 the inbox of the configured Todoist account, and all todos from the
@@ -44,7 +55,24 @@ toThingist talks to Todoist API v1 via the official
 SDK. Due to constraints in the ToDoist API, *completed todos older
 than 90 days will not be completed in Things*. This is a limitation of
 the API and not something that can be addressed programatically, so
-ensure that your crons run regularly.
+ensure that your crons run regularly. Things is read with
+[things.py](https://github.com/thingsapi/things.py), which reads the
+Things database directly; the same 90 day window is applied to it for
+symmetry.
+
+All reads are done via `things.py`. Writes are managed via the [Things
+URL scheme](https://culturedcode.com/things/help/url-scheme/)
+so Things must be installed on the machine running toThingist. Two
+things follow from that:
+
+* The URL scheme doesn't tell us the ID of a todo it creates, so we
+  have to do a second read to get the ID. This means that in some rare
+  cases, the ID won't be found and the task will be skipped in the
+  sync - next sync will pick this todo up. Deleting unsynced TODOs
+  might create weird behaviour in these cases.
+* If the ```todoist_sync``` tag doesn't exist already, it can't be
+  applied by toThingist. toThingist will warn when a tag is
+  going to be dropped.
 
 toThingist is not backwards compatible with older versions that used
 the older todoist API which no longer works. Having an old state file
@@ -54,3 +82,7 @@ state file, but be warned.
 
 Pass ```--dry-run``` (```-n```) to see what a sync would do without
 touching Todoist, Things or the state file.
+
+Pass ```--print-sql``` (```-S```) to print every SQL query things.py
+runs against the Things database, which is handy when a location or a
+todo isn't showing up where you expect.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tothingist"
+version = "0.1.0"
+description = "Bidirectional sync between Things and ToDoist"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Hugh Nowlan", email = "nosmo@nosmo.me"}]
+keywords = ["todoist", "things", "todo", "sync"]
+classifiers = [
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: MacOS :: MacOS X",
+    "Programming Language :: Python :: 3",
+]
+
+dependencies = [
+    "todoist-python==7.0.9",
+    # pythings is not published on PyPI, so it is pulled straight from
+    # git. Note that a direct reference like this makes the project
+    # ineligible for upload to PyPI.
+    "pythings @ git+https://github.com/nosmo/pythings",
+]
+
+[project.urls]
+Homepage = "https://github.com/nosmo/toThingist"
+
+[project.scripts]
+tothingist = "toThingist:main"
+
+[tool.setuptools]
+py-modules = ["toThingist", "todoistinterface"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tothingist"
-version = "0.1.0"
+version = "1.0.0"
 description = "Bidirectional sync between Things and ToDoist"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -19,10 +19,7 @@ classifiers = [
 
 dependencies = [
     "todoist-api-python>=4.0,<5",
-    # pythings is not published on PyPI, so it is pulled straight from
-    # git. Note that a direct reference like this makes the project
-    # ineligible for upload to PyPI.
-    "pythings @ git+https://github.com/nosmo/pythings",
+    "things.py>=1.0,<2",
 ]
 
 [project.urls]
@@ -32,4 +29,4 @@ Homepage = "https://github.com/nosmo/toThingist"
 tothingist = "toThingist:main"
 
 [tool.setuptools]
-py-modules = ["toThingist", "todoistinterface"]
+py-modules = ["toThingist", "thingsinterface", "todoistinterface"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tothingist"
 version = "0.1.0"
 description = "Bidirectional sync between Things and ToDoist"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [{name = "Hugh Nowlan", email = "nosmo@nosmo.me"}]
 keywords = ["todoist", "things", "todo", "sync"]
 classifiers = [
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "todoist-python==7.0.9",
+    "todoist-api-python>=4.0,<5",
     # pythings is not published on PyPI, so it is pulled straight from
     # git. Note that a direct reference like this makes the project
     # ineligible for upload to PyPI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+# Mirrors the [project] dependencies in pyproject.toml, which is the
+# source of truth - keep the two in sync.
 todoist-python==7.0.9
+# pythings is not published on PyPI, so it is pulled straight from git.
+pythings @ git+https://github.com/nosmo/pythings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Mirrors the [project] dependencies in pyproject.toml, which is the
 # source of truth - keep the two in sync.
 todoist-api-python>=4.0,<5
-# pythings is not published on PyPI, so it is pulled straight from git.
-pythings @ git+https://github.com/nosmo/pythings
+things.py>=1.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Mirrors the [project] dependencies in pyproject.toml, which is the
 # source of truth - keep the two in sync.
-todoist-python==7.0.9
+todoist-api-python>=4.0,<5
 # pythings is not published on PyPI, so it is pulled straight from git.
 pythings @ git+https://github.com/nosmo/pythings

--- a/thingsinterface.py
+++ b/thingsinterface.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Read Things db with things.py, write to Things via URL scheme
+
+things.py allows us read-only access to the Things sqlite
+file. Things itself allows us programmatic writes using the things:/// URL.
+
+See https://culturedcode.com/things/help/url-scheme/ for the URL
+scheme.
+
+"""
+
+import datetime
+import logging
+import os.path
+import subprocess
+import time
+import urllib.parse
+
+import things
+
+LOG = logging.getLogger("tothingist")
+
+# How far back to look for todo completion/cancellation. Used for
+# consistency with todoist limits
+CLOSED_WINDOW_DAYS = 90
+
+# Polling limits for querying the database after creation of a new
+# TODO, required in order to get the ID of the new TODO
+CREATE_POLL_ATTEMPTS = 40
+CREATE_POLL_INTERVAL = 0.25
+
+BUILTIN_READERS = {
+    "inbox": things.inbox,
+    "today": things.today,
+    "anytime": things.anytime,
+    "someday": things.someday,
+    "upcoming": things.upcoming,
+}
+
+# Lists we can't sync to
+RO_LISTS = ("logbook", "trash")
+
+# The URL scheme "when" value that files a new todo into each built-in
+# list. The Inbox is where a todo lands when no "when" is given at all,
+# and "upcoming" is only reachable by naming a specific date, so neither
+# has a value here.
+BUILTIN_WHEN = {
+    "inbox": None,
+    "today": "today",
+    "anytime": "anytime",
+    "someday": "someday",
+}
+
+
+class ThingsInterface(object):
+    """Wrapper for the bits of Things that toThingist needs."""
+
+    def __init__(self, filepath=None, print_sql=False):
+        """
+         filepath: path to the Things SQLite database. If None, things.py
+          picks it up from $THINGSDB or the default install location.
+         print_sql: print every SQL query things.py runs.
+        """
+
+        self.filepath = os.path.expanduser(filepath) if filepath else None
+        self.print_sql = print_sql
+        self._locations = {}
+
+    def _query_args(self):
+        """Return the things.py arguments shared by every query.
+
+        things.py opens the database per call, so these have to be
+        passed to each one rather than set up once.
+        """
+
+        args = {"print_sql": self.print_sql}
+        if self.filepath:
+            args["filepath"] = self.filepath
+        return args
+
+    def resolve_location(self, location):
+        """
+        Work out what a configured Things location refers to.
+
+        Returns a ("builtin", name), ("project", project dict) or
+        ("area", area dict) tuple. Raises KeyError if Things has no
+        such location.
+
+         location: the name of a built-in list ("Inbox", "Today",
+          "Anytime", "Someday", "Upcoming"), or the title of a project
+          or area.
+        """
+
+        if location in self._locations:
+            return self._locations[location]
+
+        name = location.strip().lower()
+        if name in BUILTIN_READERS:
+            resolved = ("builtin", name)
+        elif name in RO_LISTS:
+            raise ValueError(
+                "%r only holds todos that are already done with, so there is"
+                " nothing to sync there" % location)
+        else:
+            for project in things.projects(**self._query_args()):
+                if project["title"] == location:
+                    resolved = ("project", project)
+                    break
+            else:
+                for area in things.areas(**self._query_args()):
+                    if area["title"] == location:
+                        resolved = ("area", area)
+                        break
+                else:
+                    raise KeyError(
+                        "No Things location called %r (expected one of %s, or"
+                        " the title of a project or area)" % (
+                            location, ", ".join(sorted(BUILTIN_READERS))))
+
+        self._locations[location] = resolved
+        return resolved
+
+    def get_todos(self, location):
+        """
+        Get the todos waiting to be done in a Things location.
+
+        Completed and cancelled todos are not included - see
+        get_closed_todos() for those.
+
+         location: a location as accepted by resolve_location(). Todos
+          filed directly in an area are returned, but not those in the
+          area's projects.
+        """
+
+        kind, resolved = self.resolve_location(location)
+
+        if kind == "builtin":
+            return BUILTIN_READERS[resolved](type="to-do",
+                                             **self._query_args())
+
+        if kind == "project":
+            return things.todos(project=resolved["uuid"],
+                                **self._query_args())
+
+        return things.todos(area=resolved["uuid"], **self._query_args())
+
+    def get_closed_todos(self, days=CLOSED_WINDOW_DAYS):
+        """
+        Get todos completed or cancelled in the last `days` days.
+
+        Closing a todo takes it out of whichever list it was in, so
+        these are looked up by their stop date rather than by location.
+        """
+
+        cutoff = datetime.date.today() - datetime.timedelta(days=days)
+
+        # Only completed and cancelled todos have a stop date, so this
+        # needs no status filter of its own.
+        return things.todos(status=None, stop_date=">=%s" % cutoff.isoformat(),
+                            **self._query_args())
+
+    def create_todo(self, name, location, tags=(), notes=""):
+        """
+        Create a todo and return its Things ID, or None if it could
+        not be found again after creation.
+
+         name: the title of the todo.
+         location: the list, project or area to create the todo in.
+          See resolve_location() for the accepted values.
+         tags: tags to apply. Things ignores tags that don't already
+          exist, so these have to have been created in the app first.
+         notes: the note body of the todo.
+        """
+
+        if not name:
+            raise ValueError("Refusing to create a Things todo with no title")
+
+        parameters = {"title": name}
+
+        kind, resolved = self.resolve_location(location)
+        if kind == "builtin":
+            if resolved not in BUILTIN_WHEN:
+                raise ValueError(
+                    "Things todos cannot be created in %r - a todo can only"
+                    " end up there by being scheduled for a specific date" %
+                    location)
+            # No "when" at all is what puts a todo in the Inbox.
+            if BUILTIN_WHEN[resolved]:
+                parameters["when"] = BUILTIN_WHEN[resolved]
+        else:
+            # The URL scheme takes projects and areas alike as a list
+            # title, so the resolved location is only used to check
+            # that there is something there to create a todo in.
+            parameters["list"] = resolved["title"]
+
+        if tags:
+            self._warn_about_missing_tags(tags)
+            parameters["tags"] = ",".join(tags)
+        if notes:
+            parameters["notes"] = notes
+
+        # Any todo of this name that exists already is not the one we
+        # are about to create, however identical it looks.
+        existing = {todo["uuid"] for todo in self._get_todos_titled(name)}
+
+        self._open_url(things.url(command="add", **parameters))
+
+        for _ in range(CREATE_POLL_ATTEMPTS):
+            time.sleep(CREATE_POLL_INTERVAL)
+            created = [todo for todo in self._get_todos_titled(name)
+                       if todo["uuid"] not in existing]
+            if created:
+                # More than one match means something else created a
+                # todo of the same name at the same moment. Newest wins.
+                return max(created, key=lambda todo: todo["created"])["uuid"]
+
+        LOG.warning(
+            "Created Things todo '%s' but it had not appeared in the Things"
+            " database after %.1f seconds, so it cannot be recorded in the"
+            " state file. It will be created again on the next run unless"
+            " you delete one of the two copies.",
+            name, CREATE_POLL_ATTEMPTS * CREATE_POLL_INTERVAL)
+        return None
+
+    def set_complete(self, uuid):
+        """
+        Set a todo's state to complete.
+
+         uuid: the Things ID of the todo.
+        """
+
+        self._open_url(self._update_url(uuid, completed="true"))
+
+    def _get_todos_titled(self, title):
+        """Get every todo, closed ones included, with exactly this title."""
+
+        # search_query matches anywhere in a title or note, so the
+        # results still have to be narrowed down to an exact title.
+        return [todo
+                for todo in things.todos(search_query=title, status=None,
+                                         **self._query_args())
+                if todo["title"] == title]
+
+    def _warn_about_missing_tags(self, tags):
+        """Warn about tags that Things will silently drop."""
+
+        known = {tag["title"] for tag in things.tags(**self._query_args())}
+        missing = [tag for tag in tags if tag not in known]
+        if missing:
+            LOG.warning(
+                "Tag(s) %s do not exist in Things and will be dropped from"
+                " todos created by this run. Create them in Things to have"
+                " them applied.", ", ".join(missing))
+
+    def _update_url(self, uuid, **parameters):
+        """
+        Build a things:///update URL.
+
+        things.url() builds these too, but it reads the authentication
+        token that updates require from the default database rather than
+        from the one we were told to use.
+        """
+
+        auth_token = things.token(**self._query_args())
+        if not auth_token:
+            raise ValueError(
+                "Things URL scheme authentication token could not be read")
+
+        query = urllib.parse.urlencode(
+            {"id": uuid, **parameters, "auth-token": auth_token},
+            quote_via=urllib.parse.quote)
+        return "things:///update?%s" % query
+
+    @staticmethod
+    def _open_url(url):
+        """Hand a things:/// URL to the Things app."""
+
+        LOG.debug("Opening %s", url)
+
+        # -g leaves Things in the background, which matters when this is
+        # running from cron and the user is doing something else.
+        try:
+            subprocess.run(["open", "-g", url], check=True)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "Could not run open(1) to talk to Things - toThingist needs"
+                " to run on the Mac that Things is installed on") from exc
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                "Things refused the URL %s (open exited %d)" % (
+                    url, exc.returncode)) from exc
+
+
+def main():
+    import argparse
+    import pprint
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("location", nargs="?", default="Today",
+                        help="Things location to dump")
+    parser.add_argument("--print-sql", dest="print_sql", action="store_true",
+                        help="print the SQL queries used")
+    options = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+    interface = ThingsInterface(print_sql=options.print_sql)
+    pprint.pprint(interface.get_todos(options.location))
+
+
+if __name__ == "__main__":
+    main()

--- a/toThingist.py
+++ b/toThingist.py
@@ -18,18 +18,32 @@ import thingsinterface
 LOG = logging.getLogger("tothingist")
 
 
+# Bumped whenever the meaning of the stored IDs changes.
+# * v1: Updated for todoist API v1 IDs. Not backwards compatible with
+#   older state files lacking this flag due to changes to todoist's API.
+STATE_VERSION = 1
+
+
 def new_state():
     """Return an empty sync state mapping."""
 
-    return {"todoist_to_things": {}, "things_to_todoist": {}}
+    return {"version": STATE_VERSION,
+            "todoist_to_things": {}, "things_to_todoist": {}}
+
+
+def has_mappings(state):
+    """Return True if the state holds at least one todo mapping."""
+
+    return bool(state["todoist_to_things"] or state["things_to_todoist"])
 
 
 class ToThingist(object):
 
-    def __init__(self, todoist_obj, things_location, state):
+    def __init__(self, todoist_obj, things_location, state, dry_run=False):
         self.todoist = todoist_obj
         self.things_location = things_location
         self.state = state
+        self.dry_run = dry_run
 
     def sync_things_to_todoist(self):
         """
@@ -43,16 +57,25 @@ class ToThingist(object):
             if todo.thingsid in self.state["things_to_todoist"]:
                 todoist_id = self.state["things_to_todoist"][todo.thingsid]
                 if todo.is_closed() or todo.is_cancelled():
-                    self.todoist.set_complete(todoist_id)
-                    LOG.info("Marking task '%s' as complete in ToDoist",
-                             todo.name)
+                    if self.dry_run:
+                        LOG.info("[dry-run] Would mark task '%s' as complete"
+                                 " in ToDoist", todo.name)
+                    else:
+                        self.todoist.set_complete(todoist_id)
+                        LOG.info("Marking task '%s' as complete in ToDoist",
+                                 todo.name)
 
                 LOG.debug("Todo %s (\"%s\") synced already",
                           todo.thingsid, todo.name)
                 continue
 
+            if self.dry_run:
+                LOG.info("[dry-run] Would create ToDoist todo '%s' in the"
+                         " inbox", todo.name)
+                continue
+
             new_todo = self.todoist.create_todo(todo.name, inbox_id)
-            todoist_id = str(new_todo["id"])
+            todoist_id = str(new_todo.id)
             self.state["todoist_to_things"][todoist_id] = todo.thingsid
             self.state["things_to_todoist"][todo.thingsid] = todoist_id
 
@@ -73,22 +96,31 @@ class ToThingist(object):
 
         for todoist_todo in self.todoist.get_all_todos(
                 self.todoist.get_inbox_id()):
-            name = todoist_todo["content"]
-            todoist_id = str(todoist_todo["id"])
+            name = todoist_todo.content
+            todoist_id = str(todoist_todo.id)
 
             if todoist_id in self.state["todoist_to_things"]:
                 LOG.debug("Todo %s (\"%s\") synced already", todoist_id, name)
 
-                if todoist_todo["checked"]:
-                    # todo is checked off - check off locally
-                    to_complete = thingsinterface.ToDo._getTodoByID(
-                        self.state["todoist_to_things"][todoist_id])
-                    to_complete.complete()
-                    LOG.info("Marked '%s' as complete", name)
+                if todoist_todo.is_completed:
+                    # todo is complete, complete locally
+                    if self.dry_run:
+                        LOG.info("[dry-run] Would mark '%s' as complete in"
+                                 " Things", name)
+                    else:
+                        to_complete = thingsinterface.ToDo._getTodoByID(
+                            self.state["todoist_to_things"][todoist_id])
+                        to_complete.complete()
+                        LOG.info("Marked '%s' as complete", name)
 
                 continue
 
-            if not todoist_todo["checked"]:
+            if not todoist_todo.is_completed:
+                if self.dry_run:
+                    LOG.info("[dry-run] Would create Things todo '%s' in %s",
+                             name, self.things_location)
+                    continue
+
                 newtodo = thingsinterface.ToDo(name=name,
                                                tags=tags,
                                                location=self.things_location)
@@ -110,11 +142,27 @@ def read_state(statefile):
 
     with open(statefile, encoding="utf-8") as state_f:
         try:
-            state.update(json.load(state_f))
+            stored = json.load(state_f)
         except ValueError:
             sys.exit("Failed to read state file %s! Is it valid JSON?" %
                      statefile)
 
+    state.update(stored)
+
+    # An unrecognised version means the stored Todoist IDs were issued by
+    # a different API generation. They would all miss, so every todo would
+    # be silently re-imported - refuse rather than duplicate.
+    if stored.get("version") != STATE_VERSION and has_mappings(state):
+        sys.exit(
+            "State file %s holds version %s mappings, but this toThingist"
+            " expects version %d. Inconsistencies between versions
+            make this likely to cause a huge mess at best. Move the
+            file aside to start from an empty state." % (
+                statefile, stored.get("version", "0 (pre-API-v1)"),
+                STATE_VERSION)
+        )
+
+    state["version"] = STATE_VERSION
     return state
 
 
@@ -139,6 +187,10 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-v", "--verbose", dest="verbose",
                         help="Be verbose",
+                        action="store_true")
+    parser.add_argument("-n", "--dry-run", dest="dry_run",
+                        help="Report what would be synced without changing"
+                             " anything in Todoist, Things or the state file",
                         action="store_true")
     parser.add_argument("-c", "--config",
                         action="store", dest="configpath",
@@ -166,13 +218,16 @@ def main():
     todoist_obj = todoistinterface.ToDoistInterface(api_key)
 
     tothingist_obj = ToThingist(todoist_obj, things_location,
-                                read_state(statefile))
+                                read_state(statefile),
+                                dry_run=options.dry_run)
 
     tothingist_obj.sync_todoist_to_things(tag_import=True)
     tothingist_obj.sync_things_to_todoist()
 
-    if statefile:
-        if not any(tothingist_obj.state.values()):
+    if options.dry_run:
+        LOG.info("[dry-run] Not writing state file %s", statefile)
+    elif statefile:
+        if not has_mappings(tothingist_obj.state):
             LOG.warning("Not writing state file as there is no content"
                         " to sync. This could be in error or you'll need"
                         " to create at least one todo.")

--- a/toThingist.py
+++ b/toThingist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """toThingist - sync between Todoist and Cultured Code's Things"""
 
@@ -39,11 +39,29 @@ def has_mappings(state):
 
 class ToThingist(object):
 
-    def __init__(self, todoist_obj, things_location, state, dry_run=False):
+    def __init__(self, todoist_obj, things_obj, things_location, state,
+                 dry_run=False):
         self.todoist = todoist_obj
+        self.things = things_obj
         self.things_location = things_location
         self.state = state
         self.dry_run = dry_run
+        self._closed_things_ids = None
+
+    def closed_things_ids(self):
+        """Return the IDs of Things todos that were already closed.
+
+        Reading the Things logbook is the expensive part of a sync, so
+        it is done once. The snapshot is taken before anything is
+        changed, which is what both directions want: a todo this run
+        closes in Things was only closed because Todoist had closed it
+        already.
+        """
+
+        if self._closed_things_ids is None:
+            self._closed_things_ids = {
+                todo["uuid"] for todo in self.things.get_closed_todos()}
+        return self._closed_things_ids
 
     def sync_things_to_todoist(self):
         """
@@ -53,31 +71,42 @@ class ToThingist(object):
 
         inbox_id = self.todoist.get_inbox_id()
 
-        for todo in thingsinterface.ToDos(self.things_location):
-            if todo.thingsid in self.state["things_to_todoist"]:
-                todoist_id = self.state["things_to_todoist"][todo.thingsid]
-                if todo.is_closed() or todo.is_cancelled():
-                    if self.dry_run:
-                        LOG.info("[dry-run] Would mark task '%s' as complete"
-                                 " in ToDoist", todo.name)
-                    else:
-                        self.todoist.set_complete(todoist_id)
-                        LOG.info("Marking task '%s' as complete in ToDoist",
-                                 todo.name)
+        # Todos ToDoist has already closed need no closing again -
+        # without this, every todo closed in the last 90 days would be
+        # completed in ToDoist over and over, once per run.
+        closed_in_todoist = {str(todo.id) for todo
+                             in self.todoist.get_completed_todos(inbox_id)}
 
+        # Closing a todo takes it out of its list, so completions are
+        # picked up from the logbook rather than from the location.
+        for todo in self.things.get_closed_todos():
+            todoist_id = self.state["things_to_todoist"].get(todo["uuid"])
+            if not todoist_id or todoist_id in closed_in_todoist:
+                continue
+
+            if self.dry_run:
+                LOG.info("[dry-run] Would mark task '%s' as complete in"
+                         " ToDoist", todo["title"])
+            else:
+                self.todoist.set_complete(todoist_id)
+                LOG.info("Marking task '%s' as complete in ToDoist",
+                         todo["title"])
+
+        for todo in self.things.get_todos(self.things_location):
+            if todo["uuid"] in self.state["things_to_todoist"]:
                 LOG.debug("Todo %s (\"%s\") synced already",
-                          todo.thingsid, todo.name)
+                          todo["uuid"], todo["title"])
                 continue
 
             if self.dry_run:
                 LOG.info("[dry-run] Would create ToDoist todo '%s' in the"
-                         " inbox", todo.name)
+                         " inbox", todo["title"])
                 continue
 
-            new_todo = self.todoist.create_todo(todo.name, inbox_id)
+            new_todo = self.todoist.create_todo(todo["title"], inbox_id)
             todoist_id = str(new_todo.id)
-            self.state["todoist_to_things"][todoist_id] = todo.thingsid
-            self.state["things_to_todoist"][todo.thingsid] = todoist_id
+            self.state["todoist_to_things"][todoist_id] = todo["uuid"]
+            self.state["things_to_todoist"][todo["uuid"]] = todoist_id
 
         #TODO better return
         return self.state
@@ -102,15 +131,15 @@ class ToThingist(object):
             if todoist_id in self.state["todoist_to_things"]:
                 LOG.debug("Todo %s (\"%s\") synced already", todoist_id, name)
 
-                if todoist_todo.is_completed:
+                things_id = self.state["todoist_to_things"][todoist_id]
+                if (todoist_todo.is_completed and
+                        things_id not in self.closed_things_ids()):
                     # todo is complete, complete locally
                     if self.dry_run:
                         LOG.info("[dry-run] Would mark '%s' as complete in"
                                  " Things", name)
                     else:
-                        to_complete = thingsinterface.ToDo._getTodoByID(
-                            self.state["todoist_to_things"][todoist_id])
-                        to_complete.complete()
+                        self.things.set_complete(things_id)
                         LOG.info("Marked '%s' as complete", name)
 
                 continue
@@ -121,13 +150,15 @@ class ToThingist(object):
                              name, self.things_location)
                     continue
 
-                newtodo = thingsinterface.ToDo(name=name,
-                                               tags=tags,
-                                               location=self.things_location)
-                self.state[
-                    "todoist_to_things"][todoist_id] = newtodo.thingsid
-                self.state[
-                    "things_to_todoist"][newtodo.thingsid] = todoist_id
+                things_id = self.things.create_todo(
+                    name, self.things_location, tags=tags)
+                if not things_id:
+                    # The todo exists in Things but we have no ID to
+                    # record for it. create_todo() has said as much.
+                    continue
+
+                self.state["todoist_to_things"][todoist_id] = things_id
+                self.state["things_to_todoist"][things_id] = todoist_id
         # TODO better return
         return self.state
 
@@ -155,9 +186,9 @@ def read_state(statefile):
     if stored.get("version") != STATE_VERSION and has_mappings(state):
         sys.exit(
             "State file %s holds version %s mappings, but this toThingist"
-            " expects version %d. Inconsistencies between versions
-            make this likely to cause a huge mess at best. Move the
-            file aside to start from an empty state." % (
+            " expects version %d. Inconsistencies between versions make"
+            " this likely to cause a huge mess at best. Move the file"
+            " aside to start from an empty state." % (
                 statefile, stored.get("version", "0 (pre-API-v1)"),
                 STATE_VERSION)
         )
@@ -188,6 +219,10 @@ def main():
     parser.add_argument("-v", "--verbose", dest="verbose",
                         help="Be verbose",
                         action="store_true")
+    parser.add_argument("-S", "--print-sql", dest="print_sql",
+                        help="Print every SQL query run against the Things"
+                             " database. Implies --verbose",
+                        action="store_true")
     parser.add_argument("-n", "--dry-run", dest="dry_run",
                         help="Report what would be synced without changing"
                              " anything in Todoist, Things or the state file",
@@ -199,9 +234,11 @@ def main():
 
     options = parser.parse_args()
 
+    verbose = options.verbose or options.print_sql
+
     logging.basicConfig(
         stream=sys.stderr,
-        level=logging.DEBUG if options.verbose else logging.INFO,
+        level=logging.DEBUG if verbose else logging.INFO,
         format="%(message)s")
 
     config = configparser.ConfigParser()
@@ -215,9 +252,15 @@ def main():
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
         sys.exit("Incomplete configuration in %s: %s" % (options.configpath, e))
 
-    todoist_obj = todoistinterface.ToDoistInterface(api_key)
+    # Optional: things.py finds the database on its own unless told
+    # otherwise (see also the THINGSDB environment variable).
+    things_db = config.get("config", "thingsdb", fallback=None)
 
-    tothingist_obj = ToThingist(todoist_obj, things_location,
+    todoist_obj = todoistinterface.ToDoistInterface(api_key)
+    things_obj = thingsinterface.ThingsInterface(filepath=things_db,
+                                                 print_sql=options.print_sql)
+
+    tothingist_obj = ToThingist(todoist_obj, things_obj, things_location,
                                 read_state(statefile),
                                 dry_run=options.dry_run)
 

--- a/toThingist.py
+++ b/toThingist.py
@@ -1,21 +1,27 @@
-#!/usr/bin/python
-# This is NOT a typo - using the system python is deliberate.
+#!/usr/bin/python3
 
-import ConfigParser
-import optparse
+"""toThingist - sync between Todoist and Cultured Code's Things"""
+
+import argparse
+import configparser
 import json
-import sys
+import logging
+import os
 import os.path
+import sys
 import tempfile
 
 import todoistinterface
 
 import thingsinterface
 
-"""toThingist - sync between Todoist and Cultured Code's Things"""
+LOG = logging.getLogger("tothingist")
 
-BASE_STATE = {"incomplete": [], "complete": [],
-              "todoist_to_things": {}, "things_to_todoist": {}}
+
+def new_state():
+    """Return an empty sync state mapping."""
+
+    return {"todoist_to_things": {}, "things_to_todoist": {}}
 
 
 class ToThingist(object):
@@ -25,12 +31,9 @@ class ToThingist(object):
         self.things_location = things_location
         self.state = state
 
-    def sync_things_to_todoist(self, verbose=False):
+    def sync_things_to_todoist(self):
         """
         Sync the Things location to the ToDoist inbox.
-
-        Args:
-         verbose: bool. If true, debug output will go to stderr.
 
         """
 
@@ -40,22 +43,16 @@ class ToThingist(object):
             if todo.thingsid in self.state["things_to_todoist"]:
                 todoist_id = self.state["things_to_todoist"][todo.thingsid]
                 if todo.is_closed() or todo.is_cancelled():
-                    complete_result = self.todoist.set_complete(todoist_id)
-                    if verbose:
-                        sys.stderr.write(
-                            "Marking task '%s' as complete in ToDoist\n" % todo.name
-                        )
+                    self.todoist.set_complete(todoist_id)
+                    LOG.info("Marking task '%s' as complete in ToDoist",
+                             todo.name)
 
-                if verbose:
-                    sys.stderr.write(
-                        "Todo %s (\"%s\") synced already\n" % (
-                            todo.thingsid, todo.name
-                        )
-                    )
+                LOG.debug("Todo %s (\"%s\") synced already",
+                          todo.thingsid, todo.name)
                 continue
 
-            z = self.todoist.create_todo(todo.name, inbox_id)
-            todoist_id = z["id"]
+            new_todo = self.todoist.create_todo(todo.name, inbox_id)
+            todoist_id = str(new_todo["id"])
             self.state["todoist_to_things"][todoist_id] = todo.thingsid
             self.state["things_to_todoist"][todo.thingsid] = todoist_id
 
@@ -63,106 +60,124 @@ class ToThingist(object):
         return self.state
 
 
-    def sync_todoist_to_things(self, tag_import=False,
-                               verbose=False):
+    def sync_todoist_to_things(self, tag_import=False):
 
         """Sync todoist inbox todos into a given Things location.
 
          Args:
           tag_import: tag all imported todos with "todoist_sync"
-          verbose: bool, if True output debug to stderr
 
         """
 
-        for project in self.todoist.get_projects():
-            if project["name"] == "Inbox":
-                todoist_todos = self.todoist.get_all_todos(project["id"])
-                for todoist_todo in todoist_todos:
-                    creation_date = todoist_todo["date_added"]
-                    name = todoist_todo["content"]
-                    todoist_id = str(todoist_todo["id"])
+        tags = ["todoist_sync"] if tag_import else []
 
-                    if todoist_id in self.state["todoist_to_things"]:
-                        if verbose:
-                            sys.stderr.write(
-                                "Todo %s (\"%s\") synced already\n" % (
-                                    todoist_id, name)
-                            )
+        for todoist_todo in self.todoist.get_all_todos(
+                self.todoist.get_inbox_id()):
+            name = todoist_todo["content"]
+            todoist_id = str(todoist_todo["id"])
 
-                        if todoist_todo["checked"] == 1:
-                            # todo is checked off - check off locally
-                            to_complete = thingsinterface.ToDo._getTodoByID(
-                                self.state["todoist_to_things"][todoist_id])
-                            to_complete.complete()
-                            if verbose:
-                                sys.stderr.write(
-                                    "marked '%s' as complete" % name
-                                )
+            if todoist_id in self.state["todoist_to_things"]:
+                LOG.debug("Todo %s (\"%s\") synced already", todoist_id, name)
 
-                        continue
+                if todoist_todo["checked"]:
+                    # todo is checked off - check off locally
+                    to_complete = thingsinterface.ToDo._getTodoByID(
+                        self.state["todoist_to_things"][todoist_id])
+                    to_complete.complete()
+                    LOG.info("Marked '%s' as complete", name)
 
-                    tags = []
-                    if tag_import:
-                        tags = ["todoist_sync"]
+                continue
 
-                    if todoist_todo["checked"] != 1:
-                        newtodo = thingsinterface.ToDo(name=name,
-                                                       tags=tags,
-                                                       location=self.things_location)
-                        self.state[
-                            "todoist_to_things"][todoist_id] = newtodo.thingsid
-                        self.state[
-                            "things_to_todoist"][newtodo.thingsid] = todoist_id
+            if not todoist_todo["checked"]:
+                newtodo = thingsinterface.ToDo(name=name,
+                                               tags=tags,
+                                               location=self.things_location)
+                self.state[
+                    "todoist_to_things"][todoist_id] = newtodo.thingsid
+                self.state[
+                    "things_to_todoist"][newtodo.thingsid] = todoist_id
         # TODO better return
         return self.state
 
+
+def read_state(statefile):
+    """Load the sync state from disk, falling back to an empty state."""
+
+    state = new_state()
+
+    if not statefile or not os.path.isfile(statefile):
+        return state
+
+    with open(statefile, encoding="utf-8") as state_f:
+        try:
+            state.update(json.load(state_f))
+        except ValueError:
+            sys.exit("Failed to read state file %s! Is it valid JSON?" %
+                     statefile)
+
+    return state
+
+
+def write_state(statefile, state):
+    """Write the sync state to disk, replacing it atomically."""
+
+    # Avoid zeroing the file when the user's system has no disk space
+    # by writing a tempfile alongside it and renaming over the original
+    state_dir = os.path.dirname(statefile) or "."
+    temp_state_f = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=state_dir, delete=False)
+    try:
+        with temp_state_f:
+            json.dump(state, temp_state_f)
+        os.replace(temp_state_f.name, statefile)
+    except BaseException:
+        os.unlink(temp_state_f.name)
+        raise
+
+
 def main():
-    parser = optparse.OptionParser()
-    parser.add_option("-v", "--verbose", dest="verbose",
-                      help="Be verbose",
-                      action="store_true")
-    parser.add_option("-c", "--config",
-                      action="store", dest="configpath",
-                      default="~/.tothingist",
-                      help="alternate path for configuration file")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-v", "--verbose", dest="verbose",
+                        help="Be verbose",
+                        action="store_true")
+    parser.add_argument("-c", "--config",
+                        action="store", dest="configpath",
+                        default="~/.tothingist",
+                        help="alternate path for configuration file")
 
-    (options, args) = parser.parse_args()
+    options = parser.parse_args()
 
-    config = ConfigParser.ConfigParser()
-    config.read(os.path.expanduser(options.configpath))
-    api_key = config.get('login', 'api_token')
-    statefile = os.path.expanduser(config.get("config", "statefile"))
-    things_location = config.get("config", "thingslocation")
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if options.verbose else logging.INFO,
+        format="%(message)s")
+
+    config = configparser.ConfigParser()
+    if not config.read(os.path.expanduser(options.configpath)):
+        sys.exit("No configuration file found at %s" % options.configpath)
+
+    try:
+        api_key = config.get("login", "api_token")
+        statefile = os.path.expanduser(config.get("config", "statefile"))
+        things_location = config.get("config", "thingslocation")
+    except (configparser.NoSectionError, configparser.NoOptionError) as e:
+        sys.exit("Incomplete configuration in %s: %s" % (options.configpath, e))
+
     todoist_obj = todoistinterface.ToDoistInterface(api_key)
 
-    state = BASE_STATE.copy()
-    if statefile and os.path.isfile(statefile):
-        state_f = open(statefile)
-        try:
-            state = json.loads(state_f.read())
-        except ValueError:
-            print "Failed to open state file! Is it valid JSON?"
-            raise SystemExit(1)
-        state_f.close()
+    tothingist_obj = ToThingist(todoist_obj, things_location,
+                                read_state(statefile))
 
-    tothingist_obj = ToThingist(todoist_obj, things_location, state)
-
-    tothingist_obj.sync_todoist_to_things(tag_import=True,
-                                          verbose=options.verbose)
-    tothingist_obj.sync_things_to_todoist(verbose=options.verbose)
+    tothingist_obj.sync_todoist_to_things(tag_import=True)
+    tothingist_obj.sync_things_to_todoist()
 
     if statefile:
-        if not tothingist_obj.state:
-            sys.stderr.write(("Not writing state file as there is no content"
-                              " to sync. This could be in error or you'll need"
-                              " to create at least one todo. "))
+        if not any(tothingist_obj.state.values()):
+            LOG.warning("Not writing state file as there is no content"
+                        " to sync. This could be in error or you'll need"
+                        " to create at least one todo.")
         else:
-            # Avoid zeroing the file when the user's system has no
-            # disk space by writing a tempfile
-            temp_state_filename = tempfile.mkstemp(text=True)
-            with open(temp_state_filename[1], "w") as temp_state_f:
-                temp_state_f.write(json.dumps(tothingist_obj.state))
-            os.rename(temp_state_filename[1], statefile)
+            write_state(statefile, tothingist_obj.state)
 
 if __name__ == "__main__":
     main()

--- a/todoistinterface.py
+++ b/todoistinterface.py
@@ -2,42 +2,62 @@
 # -*- coding: utf-8 -*-
 
 import configparser
+import datetime
 import os.path
 
-import todoist
+from todoist_api_python.api import TodoistAPI
+
+# Fetch this many days of completed tasks - 90 is current max :/
+COMPLETED_WINDOW_DAYS = 90
 
 class ToDoistInterface(object):
     """Ugly wrapper for the ToDoist.com API"""
 
     def __init__(self, token):
         self.token = token
-        self.api = todoist.TodoistAPI(token)
-        self.api.sync()
+        self.api = TodoistAPI(token)
 
     def get_projects(self):
         '''
         Get all projects.
         '''
-        return self.api.projects.all()
-
-    def get_all_todos(self, project_id):
-        '''
-        Get all todo objects in a project.
-        '''
-        return [i for i in self.api.items.all()
-                if i["project_id"] == project_id]
+        return [project
+                for page in self.api.get_projects()
+                for project in page]
 
     def get_uncompleted_todos(self, project_id):
         '''
         Get all uncompleted todo items in a project.
         '''
-        return [i for i in self.get_all_todos(project_id) if not i["checked"]]
+        return [task
+                for page in self.api.get_tasks(project_id=project_id)
+                for task in page]
 
     def get_completed_todos(self, project_id):
         '''
-        Get all completed todo items in a project.
+        Get as many completed todo items in a project as possible.
+
+        API limitations mean that we cannot get all completed items
         '''
-        return [i for i in self.get_all_todos(project_id) if i["checked"]]
+        until = datetime.datetime.now(datetime.timezone.utc)
+        since = until - datetime.timedelta(days=COMPLETED_WINDOW_DAYS)
+
+        # This endpoint has no project_id parameter, so filter locally.
+        return [task
+                for page in self.api.get_completed_tasks_by_completion_date(
+                    since=since, until=until)
+                for task in page
+                if task.project_id == project_id]
+
+    def get_all_todos(self, project_id):
+        '''
+        Get all todo objects in a project.
+
+        Active and completed todos live behind separate endpoints, so
+        this necessarily costs two sets of requests rather than one.
+        '''
+        return (self.get_uncompleted_todos(project_id) +
+                self.get_completed_todos(project_id))
 
     def set_complete(self, item_id):
         '''
@@ -45,9 +65,7 @@ class ToDoistInterface(object):
 
          item_id: the todoist ID of the todo.
         '''
-        self.api.items.complete([item_id])
-        self.api.commit()
-        return True
+        return self.api.complete_task(item_id)
 
     def create_todo(self, name, project_id):
         '''
@@ -57,15 +75,16 @@ class ToDoistInterface(object):
          project_id: the id of the project in which to create a todo.
         '''
 
-        add_res = self.api.items.add(name, project_id)
-        self.api.commit()
-        return add_res
+        return self.api.add_task(name, project_id=project_id)
 
     def get_inbox_id(self):
         '''
         Get the project ID for the Inbox project.
         '''
-        return [i for i in self.get_projects() if i["name"] == "Inbox"][0]["id"]
+        for project in self.get_projects():
+            if project.is_inbox_project:
+                return project.id
+        raise LookupError("No Inbox project found in this Todoist account")
 
 def main():
     config = configparser.ConfigParser()

--- a/todoistinterface.py
+++ b/todoistinterface.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import urllib2
-import urllib
-import json
-import ConfigParser
+import configparser
 import os.path
 
 import todoist
@@ -23,23 +20,24 @@ class ToDoistInterface(object):
         '''
         return self.api.projects.all()
 
+    def get_all_todos(self, project_id):
+        '''
+        Get all todo objects in a project.
+        '''
+        return [i for i in self.api.items.all()
+                if i["project_id"] == project_id]
+
     def get_uncompleted_todos(self, project_id):
         '''
-        Get all uncompleted todo items.
+        Get all uncompleted todo items in a project.
         '''
-        return [ i for i in self.api.items.all() if not i["checked"] ]
+        return [i for i in self.get_all_todos(project_id) if not i["checked"]]
 
     def get_completed_todos(self, project_id):
         '''
-        Get all completed todo items.
+        Get all completed todo items in a project.
         '''
-        return [ i for i in self.api.items.all() if i["checked"] ]
-
-    def get_all_todos(self, project_id):
-        '''
-        Get all todo objects.
-        '''
-        return self.get_uncompleted_todos(project_id) + self.get_completed_todos(project_id)
+        return [i for i in self.get_all_todos(project_id) if i["checked"]]
 
     def set_complete(self, item_id):
         '''
@@ -59,7 +57,7 @@ class ToDoistInterface(object):
          project_id: the id of the project in which to create a todo.
         '''
 
-        add_res = self.api.items.add(name.encode('utf-8'), project_id)
+        add_res = self.api.items.add(name, project_id)
         self.api.commit()
         return add_res
 
@@ -67,16 +65,16 @@ class ToDoistInterface(object):
         '''
         Get the project ID for the Inbox project.
         '''
-        return [ i for i in self.get_projects() if i["name"] == "Inbox" ][0]
+        return [i for i in self.get_projects() if i["name"] == "Inbox"][0]["id"]
 
 def main():
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.read(os.path.expanduser("~/.tothingist"))
     api_key = config.get('login', 'api_token')
     a = ToDoistInterface(api_key)
     inbox_id = a.get_inbox_id()
     import pprint
-    pprint.pprint(a.get_all_todos(inbox_id["id"]))
+    pprint.pprint(a.get_all_todos(inbox_id))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Todoist interface

Use a supported, modern Todoist REST API instead of the old API module. 

## Things interface
It was fun while it lasted, but accessing Things via AppleScript is awful. It's slow, it's not very pleasant from a UI perspective and the handling of IDs and other elements is not sustainable or safe. Use the much faster and better supported things.py client instead for reading from Things. Use the Things URL scheme to create new objects in a manner that is well supported. 

## Modernisation

Use more idiomatic python everywhere. Remove some redundant code, fix some py2isms.