### PR TITLE
Add subtask/checklist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ and a Things list to the Todoist inbox. The completed/cancelled
 attributes of both systems are synced back and forth. Changes to
 the content of existing todo objects are not mirrored.
 
+Subtasks (single-level subtasks in todoist and task checklists within
+Things) are synced in both directions. Things checklist tasks cannot
+currently be checked off programmatically and so this must be done
+manually when a Todoist subtask is complete. Things checklist items
+that are checked off will resolve Todoist subtasks. See
+[Subtasks](#subtasks) below for more details on how subtasks are
+handled.
+
 toThingist talks to Todoist API v1 via the official
 [todoist-api-python](https://github.com/Doist/todoist-api-python)
 SDK. Due to constraints in the ToDoist API, *completed todos older
@@ -74,11 +82,35 @@ things follow from that:
   applied by toThingist. toThingist will warn when a tag is
   going to be dropped.
 
+Subtasks
+---------
+
+Todoist subtasks are ordinary todos that hang off another todo. Things
+checklists look and function the same to the user but are conceptually
+quite different, functioning as attributes of a task rather than a
+relation between task types.
+
+New subtasks are synced in both directions, attached to their parent
+tasks. Their IDs are kept in the state file in maps of their own,
+separate from the todo maps, so migration between state file formats
+is not required to start using them.
+
+*Things checklist items cannot be marked as done programmatically at
+present.* toThingist warns once per run listing the subtasks this
+applies to, and will keep doing so until they are marked done in
+Things manually. Todoist subtasks that map to Things checklist items
+will be resolved as expected.
+
+Two smaller limits, both from the same URL scheme:
+
+* toThingist supports one level of nesting for tasks - subtasks of
+  subtasks will not be synced.
+* Things checklists cannot be longer than 100 elements.
+
 toThingist is not backwards compatible with older versions that used
 the older todoist API which no longer works. Having an old state file
-could result in the recreation of old todos, referening of them or
-other messes. toThingist does its best to avoid operating on an old
-state file, but be warned.
+could result in the recreation of old todos or other messes.
+toThingist will panic on a mismatched state file.
 
 Pass ```--dry-run``` (```-n```) to see what a sync would do without
 touching Todoist, Things or the state file.

--- a/thingsinterface.py
+++ b/thingsinterface.py
@@ -31,6 +31,9 @@ CLOSED_WINDOW_DAYS = 90
 CREATE_POLL_ATTEMPTS = 40
 CREATE_POLL_INTERVAL = 0.25
 
+# Max checklist items in Things. Anything over this is dropped
+CHECKLIST_LIMIT = 100
+
 BUILTIN_READERS = {
     "inbox": things.inbox,
     "today": things.today,
@@ -41,6 +44,9 @@ BUILTIN_READERS = {
 
 # Lists we can't sync to
 RO_LISTS = ("logbook", "trash")
+
+# Statuses that things.py reports for closed checklist items
+CLOSED_CHECKLIST_STATUSES = ("completed", "canceled")
 
 # The URL scheme "when" value that files a new todo into each built-in
 # list. The Inbox is where a todo lands when no "when" is given at all,
@@ -54,7 +60,7 @@ BUILTIN_WHEN = {
 }
 
 
-class ThingsInterface(object):
+class ThingsInterface:
     """Wrapper for the bits of Things that toThingist needs."""
 
     def __init__(self, filepath=None, print_sql=False):
@@ -232,6 +238,66 @@ class ThingsInterface(object):
         """
 
         self._open_url(self._update_url(uuid, completed="true"))
+
+    def get_checklist_items(self, uuid):
+        """
+        Get checklist items of a todo. All items will be returned,
+        open, cancelled or completed.
+
+         uuid: the Things ID of the todo the checklist hangs off.
+
+        """
+
+        return things.checklist_items(uuid, **self._query_args())
+
+    def create_checklist_item(self, uuid, name):
+        """
+        Append an item to a todo's checklist and return the item's
+        Things ID. Returns None if the item couldn't be found or if a
+        checklist is over 100 items.
+
+         uuid: the Things ID of the todo to append to.
+         name: the title of the checklist item.
+        """
+
+        if not name:
+            raise ValueError(
+                "Refusing to create a Things checklist item with no title"
+            )
+
+        # The URL scheme separates checklist items by newline, so a
+        # title containing one would silently arrive as several items -
+        # and only one of them could be recorded in the state file.
+        title = " ".join(name.splitlines())
+        if title != name:
+            LOG.warning(
+                "Checklist item '%s' spans several lines. Things reads a"
+                " line break as the start of another item, so it has been"
+                " flattened to '%s'.", name, title)
+
+        existing = {item["uuid"] for item in self.get_checklist_items(uuid)}
+
+        self._open_url(self._update_url(
+            uuid, **{"append-checklist-items": title}))
+
+        for _ in range(CREATE_POLL_ATTEMPTS):
+            time.sleep(CREATE_POLL_INTERVAL)
+            created = [item for item in self.get_checklist_items(uuid)
+                       if item["uuid"] not in existing
+                       and item["title"] == title]
+            if created:
+                # As in create_todo(), a second match means something
+                # else added an identical item just now. Newest wins.
+                return max(created, key=lambda item: item["created"])["uuid"]
+
+        LOG.warning(
+            "Asked Things to add checklist item '%s', but it had not appeared"
+            " on todo %s after %.1f seconds, so it cannot be recorded in the"
+            " state file. Either the todo is at its %d item limit, or the"
+            " item will be added again on the next run unless you delete it.",
+            title, uuid, CREATE_POLL_ATTEMPTS * CREATE_POLL_INTERVAL,
+            CHECKLIST_LIMIT)
+        return None
 
     def _get_todos_titled(self, title):
         """Get every todo, closed ones included, with exactly this title."""

--- a/toThingist.py
+++ b/toThingist.py
@@ -25,16 +25,24 @@ STATE_VERSION = 1
 
 
 def new_state():
-    """Return an empty sync state mapping."""
+    """Return an empty sync state mapping.
+
+    Subtasks a mapping of their own as Things checklists are not
+    todos, but todoist subtasks are. An ID can/will appear in both.
+    """
 
     return {"version": STATE_VERSION,
-            "todoist_to_things": {}, "things_to_todoist": {}}
+            "todoist_to_things": {}, "things_to_todoist": {},
+            "todoist_to_things_subtasks": {},
+            "things_to_todoist_subtasks": {}}
 
 
 def has_mappings(state):
     """Return True if the state holds at least one todo mapping."""
 
-    return bool(state["todoist_to_things"] or state["things_to_todoist"])
+    return any(state[key] for key in
+               ("todoist_to_things", "things_to_todoist",
+                "todoist_to_things_subtasks", "things_to_todoist_subtasks"))
 
 
 class ToThingist(object):
@@ -47,6 +55,12 @@ class ToThingist(object):
         self.state = state
         self.dry_run = dry_run
         self._closed_things_ids = None
+        self._unclosable_checklist_items = []
+
+        # used when doing a dry run, where no parents will be
+        # available for created sub-objects
+        self._dry_run_todoist_parents = set()
+        self._dry_run_things_parents = set()
 
     def closed_things_ids(self):
         """Return the IDs of Things todos that were already closed.
@@ -92,7 +106,9 @@ class ToThingist(object):
                 LOG.info("Marking task '%s' as complete in ToDoist",
                          todo["title"])
 
-        for todo in self.things.get_todos(self.things_location):
+        things_todos = self.things.get_todos(self.things_location)
+
+        for todo in things_todos:
             if todo["uuid"] in self.state["things_to_todoist"]:
                 LOG.debug("Todo %s (\"%s\") synced already",
                           todo["uuid"], todo["title"])
@@ -101,6 +117,7 @@ class ToThingist(object):
             if self.dry_run:
                 LOG.info("[dry-run] Would create ToDoist todo '%s' in the"
                          " inbox", todo["title"])
+                self._dry_run_things_parents.add(todo["uuid"])
                 continue
 
             new_todo = self.todoist.create_todo(todo["title"], inbox_id)
@@ -108,9 +125,82 @@ class ToThingist(object):
             self.state["todoist_to_things"][todoist_id] = todo["uuid"]
             self.state["things_to_todoist"][todo["uuid"]] = todoist_id
 
-        #TODO better return
+        # Done after the loop above so that checklists hanging off todos
+        # created by this very run have a Todoist parent to go under.
+        self.sync_things_subtasks_to_todoist(things_todos, closed_in_todoist)
+
+        # TODO better return
         return self.state
 
+    def sync_things_subtasks_to_todoist(self, things_todos, closed_in_todoist):
+        """
+        Sync the checklists of synced Things todos to Todoist subtasks.
+
+        Only consider open todos - a closed todoist todo completes all
+        subtasks, and we consider checklists with a completed owner
+        todo to be the same.
+
+         things_todos: todos in the Things location, as returned by
+          ThingsInterface.get_todos().
+         closed_in_todoist: IDs already-closed todoist todos, to avoid
+          continuously closing the same totos.
+
+        """
+
+        for todo in things_todos:
+            parent_id = self.state["things_to_todoist"].get(todo["uuid"])
+            if not parent_id:
+                # Either this is a dry run and the todo was reported
+                # rather than created, or create_todo() could not find
+                # the todo it had just made and has said so.
+                if todo["uuid"] in self._dry_run_things_parents:
+                    self._report_subtasks_of_unmade_parent(todo)
+                continue
+
+            for item in self.things.get_checklist_items(todo["uuid"]):
+                closed = (item["status"] in
+                          thingsinterface.CLOSED_CHECKLIST_STATUSES)
+                todoist_id = self.state["things_to_todoist_subtasks"].get(
+                    item["uuid"])
+
+                if todoist_id:
+                    if not closed or todoist_id in closed_in_todoist:
+                        continue
+
+                    if self.dry_run:
+                        LOG.info("[dry-run] Would mark subtask '%s' as"
+                                 " complete in ToDoist", item["title"])
+                    else:
+                        self.todoist.set_complete(todoist_id)
+                        LOG.info("Marking subtask '%s' as complete in ToDoist",
+                                 item["title"])
+                    continue
+
+                # don't sync already-closed unsynced tasks
+                if closed:
+                    continue
+
+                if self.dry_run:
+                    LOG.info("[dry-run] Would create ToDoist subtask '%s'"
+                             " under '%s'", item["title"], todo["title"])
+                    continue
+
+                new_todo = self.todoist.create_todo(item["title"],
+                                                    parent_id=parent_id)
+                todoist_id = str(new_todo.id)
+                self.state["todoist_to_things_subtasks"][todoist_id] = \
+                    item["uuid"]
+                self.state["things_to_todoist_subtasks"][item["uuid"]] = \
+                    todoist_id
+
+    def _report_subtasks_of_unmade_parent(self, todo):
+        """Report the Todoist subtasks a dry run would have created."""
+
+        for item in self.things.get_checklist_items(todo["uuid"]):
+            if item["status"] in thingsinterface.CLOSED_CHECKLIST_STATUSES:
+                continue
+            LOG.info("[dry-run] Would create ToDoist subtask '%s' under"
+                     " '%s'", item["title"], todo["title"])
 
     def sync_todoist_to_things(self, tag_import=False):
 
@@ -123,8 +213,14 @@ class ToThingist(object):
 
         tags = ["todoist_sync"] if tag_import else []
 
-        for todoist_todo in self.todoist.get_all_todos(
-                self.todoist.get_inbox_id()):
+        todoist_todos = self.todoist.get_all_todos(self.todoist.get_inbox_id())
+
+        for todoist_todo in todoist_todos:
+            # This list will include subtasks - we cover those later
+            # so ignore for now
+            if todoist_todo.parent_id:
+                continue
+
             name = todoist_todo.content
             todoist_id = str(todoist_todo.id)
 
@@ -148,6 +244,7 @@ class ToThingist(object):
                 if self.dry_run:
                     LOG.info("[dry-run] Would create Things todo '%s' in %s",
                              name, self.things_location)
+                    self._dry_run_todoist_parents.add(todoist_id)
                     continue
 
                 things_id = self.things.create_todo(
@@ -159,8 +256,121 @@ class ToThingist(object):
 
                 self.state["todoist_to_things"][todoist_id] = things_id
                 self.state["things_to_todoist"][things_id] = todoist_id
+
+        self.sync_todoist_subtasks_to_things(todoist_todos)
+
         # TODO better return
         return self.state
+
+    def sync_todoist_subtasks_to_things(self, todoist_todos):
+        """
+        Sync Todoist subtasks into Things todo checklists.
+
+        We convert todoist subtasks (which are actually true tasks) to
+        Things checklists (which are attributes of things tasks).
+        * For now we support a single level of subtask-ery, and
+           ignore subsubtasks.
+        * We also can't sync resolved subtasks into checklists in Things
+          due to limitations of the URL system. We could hack around this
+          with applescript as in pythings but who wants to go back to
+          doing that ;_;
+
+         todoist_todos: todos from the Todoist inbox, as returned by
+          ToDoistInterface.get_all_todos().
+
+        """
+
+        subtasks_by_parent = self.todoist.get_subtasks(todoist_todos)
+
+        for parent_id, subtasks in subtasks_by_parent.items():
+            things_parent = self.state["todoist_to_things"].get(parent_id)
+            if not things_parent:
+                if parent_id in self.state["todoist_to_things_subtasks"]:
+                    LOG.warning(
+                        "Todoist todos %s sit below a subtask, and a Things"
+                        " checklist item cannot hold a checklist of its own,"
+                        " so they have not been synced.",
+                        ", ".join("'%s'" % task.content for task in subtasks))
+                elif parent_id in self._dry_run_todoist_parents:
+                    for subtask in subtasks:
+                        if not subtask.is_completed:
+                            LOG.info(
+                                "[dry-run] Would add checklist item '%s' to a"
+                                " Things todo in %s",
+                                subtask.content, self.things_location)
+                # Otherwise we haven't seen a parent at all
+                continue
+
+            closed_items = None
+
+            for subtask in subtasks:
+                name = subtask.content
+                subtask_id = str(subtask.id)
+                item_uuid = self.state["todoist_to_things_subtasks"].get(
+                    subtask_id)
+
+                if item_uuid:
+                    if not subtask.is_completed:
+                        continue
+
+                    # Reading the checklist is only worth it once it is
+                    # known that there is a completion to reflect.
+                    if closed_items is None:
+                        closed_items = self.closed_checklist_items(
+                            things_parent)
+                    if item_uuid not in closed_items:
+                        self._unclosable_checklist_items.append(name)
+                    continue
+
+                if subtask.is_completed:
+                    continue
+
+                if self.dry_run:
+                    LOG.info("[dry-run] Would add checklist item '%s' to a"
+                             " Things todo in %s", name, self.things_location)
+                    continue
+
+                item_uuid = self.things.create_checklist_item(
+                    things_parent, name)
+                if not item_uuid:
+                    # The item may well be on the todo, but there is no
+                    # ID to record. create_checklist_item() has said so.
+                    continue
+
+                self.state["todoist_to_things_subtasks"][subtask_id] = \
+                    item_uuid
+                self.state["things_to_todoist_subtasks"][item_uuid] = \
+                    subtask_id
+
+        self._warn_about_unclosable_items()
+
+    def closed_checklist_items(self, things_uuid):
+        """Return the IDs of a Things todo's checklist items that are done."""
+
+        return {item["uuid"]
+                for item in self.things.get_checklist_items(things_uuid)
+                if item["status"] in thingsinterface.CLOSED_CHECKLIST_STATUSES}
+
+    def _warn_about_unclosable_items(self):
+        """Report the completions that could not be mirrored in Things.
+
+        Gathered up and reported in one go rather than one warning per
+        item, as this is a standing state of affairs rather than a
+        one-off: every run will find these again until they are ticked
+        off in Things by hand.
+        """
+
+        if not self._unclosable_checklist_items:
+            return
+
+        LOG.warning(
+            "Todoist subtask(s) %s are complete, but the Things URL scheme"
+            " offers no way to tick off a single checklist item, so they have"
+            " been left alone. Tick them off in Things to have the two match"
+            " and to stop this warning.",
+            ", ".join("'%s'" % name
+                      for name in self._unclosable_checklist_items))
+        self._unclosable_checklist_items = []
 
 
 def read_state(statefile):
@@ -249,8 +459,10 @@ def main():
         api_key = config.get("login", "api_token")
         statefile = os.path.expanduser(config.get("config", "statefile"))
         things_location = config.get("config", "thingslocation")
-    except (configparser.NoSectionError, configparser.NoOptionError) as e:
-        sys.exit("Incomplete configuration in %s: %s" % (options.configpath, e))
+    except (configparser.NoSectionError, configparser.NoOptionError) as exc:
+        sys.exit(
+            "Incomplete configuration in %s: %s" % (options.configpath, exc)
+        )
 
     # Optional: things.py finds the database on its own unless told
     # otherwise (see also the THINGSDB environment variable).
@@ -276,6 +488,7 @@ def main():
                         " to create at least one todo.")
         else:
             write_state(statefile, tothingist_obj.state)
+
 
 if __name__ == "__main__":
     main()

--- a/todoistinterface.py
+++ b/todoistinterface.py
@@ -10,7 +10,8 @@ from todoist_api_python.api import TodoistAPI
 # Fetch this many days of completed tasks - 90 is current max :/
 COMPLETED_WINDOW_DAYS = 90
 
-class ToDoistInterface(object):
+
+class ToDoistInterface:
     """Ugly wrapper for the ToDoist.com API"""
 
     def __init__(self, token):
@@ -28,6 +29,9 @@ class ToDoistInterface(object):
     def get_uncompleted_todos(self, project_id):
         '''
         Get all uncompleted todo items in a project.
+
+        Subtasks are todos like any other, so they are included here.
+        See also get_subtasks().
         '''
         return [task
                 for page in self.api.get_tasks(project_id=project_id)
@@ -51,7 +55,7 @@ class ToDoistInterface(object):
 
     def get_all_todos(self, project_id):
         '''
-        Get all todo objects in a project.
+        Get all todo objects in a project, subtasks included.
 
         Active and completed todos live behind separate endpoints, so
         this necessarily costs two sets of requests rather than one.
@@ -67,15 +71,42 @@ class ToDoistInterface(object):
         '''
         return self.api.complete_task(item_id)
 
-    def create_todo(self, name, project_id):
+    def create_todo(self, name, project_id=None, parent_id=None):
         '''
         Create a new todo.
 
          name: the label for the todo item.
          project_id: the id of the project in which to create a todo.
+         parent_id: the id of the todo to make this task a subtask of
+          A subtask lives in its parent's project, so not rqeuired here.
         '''
 
+        if parent_id:
+            return self.api.add_task(name, parent_id=parent_id)
+
+        if not project_id:
+            raise ValueError(
+                "A todoist todo must have either a project or parent"
+            )
+
         return self.api.add_task(name, project_id=project_id)
+
+    @staticmethod
+    def get_subtasks(todos):
+        '''
+        Group todos by their parent ID
+
+        Subtasks appear alongside all other todos, this
+        function filters them out.
+
+         todos: todo objects as returned by get_all_todos().
+        '''
+
+        subtasks = {}
+        for todo in todos:
+            if todo.parent_id:
+                subtasks.setdefault(str(todo.parent_id), []).append(todo)
+        return subtasks
 
     def get_inbox_id(self):
         '''
@@ -86,14 +117,16 @@ class ToDoistInterface(object):
                 return project.id
         raise LookupError("No Inbox project found in this Todoist account")
 
+
 def main():
     config = configparser.ConfigParser()
     config.read(os.path.expanduser("~/.tothingist"))
     api_key = config.get('login', 'api_token')
-    a = ToDoistInterface(api_key)
-    inbox_id = a.get_inbox_id()
+    api = ToDoistInterface(api_key)
+    inbox_id = api.get_inbox_id()
     import pprint
-    pprint.pprint(a.get_all_todos(inbox_id))
+    pprint.pprint(api.get_all_todos(inbox_id))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Support subtasks in todoist, and checklists in Things. To the user these are conceptually similar concepts, but in implementation they are wildly different. Todoist considers a subtask a true task (hence it being something that can be moved around etc). Things considers a checklist to purely be an attribute of a Todo.

Closing Todoist subtasks is supported, completing Things checklists is not, sadly.