### PR TITLE
Add project-to-project mapping

### DIFF
--- a/.tothingist
+++ b/.tothingist
@@ -1,9 +1,18 @@
-[DEFAULT]
-thingslocation: Today
 [login]
 api_token: f00f00f00f00f00f00f
 [config]
 statefile: ~/.tothingist_state
-thingslocation: Today
 # Optional - specify a things database. Usually not required
 #thingsdb: ~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-XXXXXX/Things Database.thingsdatabase/main.sqlite
+# Optional - sync todoist Inbox with this location in things. Useful for basic operations, but generally rendered a little obsolete by the `[projects`] structure.
+#thingslocation: Today
+
+# Which Todoist project syncs with which Things list, project or area,
+# one pair per line. Todoist project on the left, Things project on the right
+
+# Where a name is ambiguous, a Todoist project inside another can be written
+# "Parent/Child" and a Things project inside an area "Area/Project".
+[projects]
+Inbox: Today
+Work: Work
+Household/Renovation: Home/Renovation

--- a/README.md
+++ b/README.md
@@ -25,19 +25,45 @@ Writing to Things requires the use of the Things URL scheme. See the
 documentation](https://culturedcode.com/things/support/articles/2803573/#overview-authorization)
 for details on how to enable its use.
 
-The ```thingslocation``` option is used to indicate where a todo
-should go once imported from todoist. This can be one of the built-in
-Things lists (```Inbox```, ```Today```, ```Anytime```, ```Someday```)
-or the title of a project or area. Don't use ```Upcoming``` as this
-can't be written to in normal situations
+The ```[projects]``` section configures which Todoist project syncs with
+which Things location, one pair per line:
+
+```
+[projects]
+Inbox: Today
+Work: Work
+Household/Renovation: Home/Renovation
+```
+
+On the left is a Todoist project name, where ```Inbox``` always means
+the Todoist inbox whatever the account's language calls it. On the
+right is one of the built-in Things lists (```Inbox```, ```Today```,
+```Anytime```, ```Someday```) or the title of a project or area. Don't
+use ```Upcoming``` as this can't be written to in normal situations.
+
+Names are matched exactly, case included. Both applications allow two
+projects to share a name, so where a name is ambiguous a Todoist
+project can be named by its ```Parent/Child``` path and a Things
+project by its ```Area/Project``` one. toThingist says which paths it
+found rather than guessing between them.
+
+Two Todoist projects can't be mapped to the same Things location.
+Things can get a little unpredictable if a project is synced that
+contains todos that are also in Today for example, as a todo will only
+get synced once but the relations will be maintained.
+
+For backwards compatibility, a config file with no ```[projects]```
+section falls back to the ```thingslocation``` option, which is the
+same as mapping ```Inbox``` to that location. When ```[projects]``` is
+present, ```thingslocation``` is ignored.
 
 The optional ```thingsdb``` option points at the Things database. This
 isn't generally required as thingsapi can find it in most cases. The
 `THINGSDB` environment variable can also be set.
 
-Running toThingist.py will sync all todos in ```thingslocation``` to
-the inbox of the configured Todoist account, and all todos from the
-Todoist inbox to ```thingslocation```. The mapping between todos is
+Running toThingist.py will sync all todos in the Things location to
+the Todoist project and all todos in the Todoist project to the Things
+location, for every configured project. The mapping between todos is
 maintained in the state file.
 
 The script is largely designed with an eye to it being run via cron.
@@ -45,10 +71,11 @@ The script is largely designed with an eye to it being run via cron.
 Current state
 ---------
 
-The script can currently sync the Todoist inbox to a list in Things,
-and a Things list to the Todoist inbox. The completed/cancelled
-attributes of both systems are synced back and forth. Changes to
-the content of existing todo objects are not mirrored.
+ToThingist can currently sync any number of Todoist projects to
+matching Things lists, projects or areas, and back again. The
+completed/cancelled attributes of both systems are synced back and
+forth, wherever a todo was synced to. Changes to things like text will
+not be synced between existing todos.
 
 Subtasks (single-level subtasks in todoist and task checklists within
 Things) are synced in both directions. Things checklist tasks cannot

--- a/thingsinterface.py
+++ b/thingsinterface.py
@@ -48,6 +48,9 @@ RO_LISTS = ("logbook", "trash")
 # Statuses that things.py reports for closed checklist items
 CLOSED_CHECKLIST_STATUSES = ("completed", "canceled")
 
+# Projects with identical names in different areas use this divider
+LOCATION_PATH_SEPARATOR = "/"
+
 # The URL scheme "when" value that files a new todo into each built-in
 # list. The Inbox is where a todo lands when no "when" is given at all,
 # and "upcoming" is only reachable by naming a specific date, so neither
@@ -95,8 +98,8 @@ class ThingsInterface:
         such location.
 
          location: the name of a built-in list ("Inbox", "Today",
-          "Anytime", "Someday", "Upcoming"), or the title of a project
-          or area.
+          "Anytime", "Someday", "Upcoming"), the title of a project or
+          area, or the "Area/Project" path of a project.
         """
 
         if location in self._locations:
@@ -110,23 +113,49 @@ class ThingsInterface:
                 "%r only holds todos that are already done with, so there is"
                 " nothing to sync there" % location)
         else:
-            for project in things.projects(**self._query_args()):
-                if project["title"] == location:
-                    resolved = ("project", project)
-                    break
-            else:
-                for area in things.areas(**self._query_args()):
-                    if area["title"] == location:
-                        resolved = ("area", area)
-                        break
-                else:
-                    raise KeyError(
-                        "No Things location called %r (expected one of %s, or"
-                        " the title of a project or area)" % (
-                            location, ", ".join(sorted(BUILTIN_READERS))))
+            resolved = self._resolve_list(location.strip())
 
         self._locations[location] = resolved
         return resolved
+
+    def _resolve_list(self, title):
+        """
+        Find the project or area by title.
+
+        Check projects before areas
+
+         title: the title of a project or area, or the "Area/Project"
+          path of a project in case of an overlapping project name
+        """
+
+        for kind, listing in (("project", things.projects),
+                              ("area", things.areas)):
+            matches = [entry for entry in listing(**self._query_args())
+                       if title in (entry["title"], self._list_path(entry))]
+
+            if len(matches) == 1:
+                return (kind, matches[0])
+
+            if matches:
+                raise ValueError(
+                    "Things holds %d %ss called %r - use one of %s instead" % (
+                        len(matches), kind, title,
+                        ", ".join(sorted(self._list_path(entry)
+                                         for entry in matches))))
+
+        raise KeyError(
+            "No Things location called %r (expected one of %s, or the title"
+            " of a project or area)" % (
+                title, ", ".join(sorted(BUILTIN_READERS))))
+
+    @staticmethod
+    def _list_path(entry):
+        """Return the "Area/Project" path of a project or area."""
+
+        if entry.get("area_title"):
+            return "%s%s%s" % (entry["area_title"], LOCATION_PATH_SEPARATOR,
+                               entry["title"])
+        return entry["title"]
 
     def get_todos(self, location):
         """
@@ -196,10 +225,8 @@ class ThingsInterface:
             if BUILTIN_WHEN[resolved]:
                 parameters["when"] = BUILTIN_WHEN[resolved]
         else:
-            # The URL scheme takes projects and areas alike as a list
-            # title, so the resolved location is only used to check
-            # that there is something there to create a todo in.
-            parameters["list"] = resolved["title"]
+            # Resolve a UUID in order to account for duplicate names
+            parameters["list-id"] = resolved["uuid"]
 
         if tags:
             self._warn_about_missing_tags(tags)
@@ -211,7 +238,7 @@ class ThingsInterface:
         # are about to create, however identical it looks.
         existing = {todo["uuid"] for todo in self._get_todos_titled(name)}
 
-        self._open_url(things.url(command="add", **parameters))
+        self._open_url(self._add_url(parameters))
 
         for _ in range(CREATE_POLL_ATTEMPTS):
             time.sleep(CREATE_POLL_INTERVAL)
@@ -319,6 +346,21 @@ class ThingsInterface:
                 "Tag(s) %s do not exist in Things and will be dropped from"
                 " todos created by this run. Create them in Things to have"
                 " them applied.", ", ".join(missing))
+
+    @staticmethod
+    def _add_url(parameters):
+        """Build a things:///add URL.
+
+        Similar to things.url(), but account for list-id as it is not
+        an accepted keyword.
+
+         parameters: the URL parameters for a todo.
+
+        """
+
+        query = urllib.parse.urlencode(parameters,
+                                       quote_via=urllib.parse.quote)
+        return "things:///add?%s" % query
 
     def _update_url(self, uuid, **parameters):
         """

--- a/toThingist.py
+++ b/toThingist.py
@@ -3,6 +3,7 @@
 """toThingist - sync between Todoist and Cultured Code's Things"""
 
 import argparse
+import collections
 import configparser
 import json
 import logging
@@ -22,6 +23,18 @@ LOG = logging.getLogger("tothingist")
 # * v1: Updated for todoist API v1 IDs. Not backwards compatible with
 #   older state files lacking this flag due to changes to todoist's API.
 STATE_VERSION = 1
+
+# The config section holding the project mappings, one
+# "todoist project: things location" per line.
+MAPPING_SECTION = "projects"
+
+# Used to spot a required option that isn't there, as None and "" are
+# both things an option could legitimately be set to.
+_REQUIRED = object()
+
+# Bidirectional mapping between todoist projects and things location
+SyncPair = collections.namedtuple("SyncPair",
+                                  ["todoist_project", "things_location"])
 
 
 def new_state():
@@ -45,16 +58,72 @@ def has_mappings(state):
                 "todoist_to_things_subtasks", "things_to_todoist_subtasks"))
 
 
+def get_option(config, section, option):
+    """Get a config option, case insensitive.
+
+     option: the name of the option, in lower case.
+    """
+
+    for name, value in config.items(section):
+        if name.lower() == option:
+            return value
+
+    return None
+
+
+def read_pairs(config):
+    """Work out which Todoist projects sync with which Things locations.
+
+    Or use thingslocation as a default.
+    """
+
+    if not config.has_section(MAPPING_SECTION):
+        return [SyncPair(todoistinterface.INBOX_NAME,
+                         get_option(config, "config", "thingslocation"))]
+
+    defaults = {name.lower() for name in config.defaults()}
+
+    pairs = []
+    for project, location in config.items(MAPPING_SECTION):
+        if project.lower() in defaults:
+            continue
+        if not location.strip():
+            raise ValueError(
+                "Todoist project %r in [%s] is not mapped to any Things"
+                " location" % (project, MAPPING_SECTION))
+        pairs.append(SyncPair(project.strip(), location.strip()))
+
+    if not pairs:
+        raise ValueError(
+            "The [%s] section maps nothing - give it a line per pair of"
+            " projects to sync, in the form"
+            " 'todoist project: things location'" % MAPPING_SECTION)
+
+    # refuse to map a things location to two todoist projects
+    locations = collections.Counter(pair.things_location for pair in pairs)
+    repeated = sorted(location for location, count in locations.items()
+                      if count > 1)
+    if repeated:
+        raise ValueError(
+            "Things location(s) %s are mapped to more than one Todoist"
+            " project in [%s]" % (", ".join(repeated), MAPPING_SECTION))
+
+    return pairs
+
+
 class ToThingist(object):
 
-    def __init__(self, todoist_obj, things_obj, things_location, state,
-                 dry_run=False):
+    def __init__(self, todoist_obj, things_obj, pairs, state, dry_run=False):
         self.todoist = todoist_obj
         self.things = things_obj
-        self.things_location = things_location
+        self.pairs = list(pairs)
         self.state = state
         self.dry_run = dry_run
+        self._closed_things_todos = None
         self._closed_things_ids = None
+        self._completed_todoist_todos = None
+        self._completed_todoist_ids = None
+        self._todoist_project_ids = {}
         self._unclosable_checklist_items = []
 
         # used when doing a dry run, where no parents will be
@@ -62,8 +131,29 @@ class ToThingist(object):
         self._dry_run_todoist_parents = set()
         self._dry_run_things_parents = set()
 
-    def closed_things_ids(self):
-        """Return the IDs of Things todos that were already closed.
+    def todoist_project_id(self, pair):
+        """Return the ID of the Todoist project a pair syncs with."""
+
+        if pair.todoist_project not in self._todoist_project_ids:
+            self._todoist_project_ids[pair.todoist_project] = (
+                self.todoist.resolve_project_id(pair.todoist_project))
+        return self._todoist_project_ids[pair.todoist_project]
+
+    def check_pairs(self):
+        """Check that every mapped project and location exists.
+
+        Looking them all up before syncing anything turns a typo into
+        one error rather than a half-done sync.
+        """
+
+        for pair in self.pairs:
+            self.todoist_project_id(pair)
+            self.things.resolve_location(pair.things_location)
+            LOG.debug("Syncing Todoist project '%s' with Things '%s'",
+                      pair.todoist_project, pair.things_location)
+
+    def closed_things_todos(self):
+        """Return the Things todos that were already closed.
 
         Reading the Things logbook is the expensive part of a sync, so
         it is done once. The snapshot is taken before anything is
@@ -72,28 +162,103 @@ class ToThingist(object):
         already.
         """
 
+        if self._closed_things_todos is None:
+            self._closed_things_todos = self.things.get_closed_todos()
+        return self._closed_things_todos
+
+    def closed_things_ids(self):
+        """Return the IDs of Things todos that were already closed."""
+
         if self._closed_things_ids is None:
             self._closed_things_ids = {
-                todo["uuid"] for todo in self.things.get_closed_todos()}
+                todo["uuid"] for todo in self.closed_things_todos()}
         return self._closed_things_ids
+
+    def completed_todoist_todos(self, project_id=None):
+        """Return the Todoist todos that were already completed.
+
+        Todoist serves completed todos from an endpoint that can't
+        filter by project, so they are fetched once for the whole
+        account and grouped here rather than fetched once per mapping.
+
+         project_id: only return the todos of this project.
+        """
+
+        if self._completed_todoist_todos is None:
+            self._completed_todoist_todos = {}
+            for todo in self.todoist.get_completed_todos():
+                self._completed_todoist_todos.setdefault(
+                    str(todo.project_id), []).append(todo)
+
+        if project_id is None:
+            return [todo
+                    for todos in self._completed_todoist_todos.values()
+                    for todo in todos]
+        return self._completed_todoist_todos.get(str(project_id), [])
+
+    def completed_todoist_ids(self):
+        """Return the IDs of the todos Todoist has already completed."""
+
+        if self._completed_todoist_ids is None:
+            self._completed_todoist_ids = {
+                str(todo.id) for todo in self.completed_todoist_todos()}
+        return self._completed_todoist_ids
 
     def sync_things_to_todoist(self):
         """
-        Sync the Things location to the ToDoist inbox.
+        Sync each mapped Things location to its ToDoist project.
 
         """
 
-        inbox_id = self.todoist.get_inbox_id()
+        self.complete_in_todoist()
+
+        for pair in self.pairs:
+            project_id = self.todoist_project_id(pair)
+            things_todos = self.things.get_todos(pair.things_location)
+
+            for todo in things_todos:
+                if todo["uuid"] in self.state["things_to_todoist"]:
+                    LOG.debug("Todo %s (\"%s\") synced already",
+                              todo["uuid"], todo["title"])
+                    continue
+
+                if self.dry_run:
+                    LOG.info("[dry-run] Would create ToDoist todo '%s' in"
+                             " '%s'", todo["title"], pair.todoist_project)
+                    self._dry_run_things_parents.add(todo["uuid"])
+                    continue
+
+                new_todo = self.todoist.create_todo(todo["title"], project_id)
+                todoist_id = str(new_todo.id)
+                self.state["todoist_to_things"][todoist_id] = todo["uuid"]
+                self.state["things_to_todoist"][todo["uuid"]] = todoist_id
+
+            # Done after the loop above so that checklists hanging off
+            # todos created by this very run have a Todoist parent to go
+            # under.
+            self.sync_things_subtasks_to_todoist(things_todos,
+                                                 self.completed_todoist_ids())
+
+        #TODO better return
+        return self.state
+
+    def complete_in_todoist(self):
+        """
+        Complete in ToDoist the todos that Things has closed.
+
+        Closing a todo takes it out of its list, so completions are
+        picked up from the logbook rather than from the mapped
+        locations. That also means a todo is completed in whichever
+        project it was synced to, without caring which mapping first
+        carried it over.
+        """
 
         # Todos ToDoist has already closed need no closing again -
         # without this, every todo closed in the last 90 days would be
         # completed in ToDoist over and over, once per run.
-        closed_in_todoist = {str(todo.id) for todo
-                             in self.todoist.get_completed_todos(inbox_id)}
+        closed_in_todoist = self.completed_todoist_ids()
 
-        # Closing a todo takes it out of its list, so completions are
-        # picked up from the logbook rather than from the location.
-        for todo in self.things.get_closed_todos():
+        for todo in self.closed_things_todos():
             todoist_id = self.state["things_to_todoist"].get(todo["uuid"])
             if not todoist_id or todoist_id in closed_in_todoist:
                 continue
@@ -105,32 +270,6 @@ class ToThingist(object):
                 self.todoist.set_complete(todoist_id)
                 LOG.info("Marking task '%s' as complete in ToDoist",
                          todo["title"])
-
-        things_todos = self.things.get_todos(self.things_location)
-
-        for todo in things_todos:
-            if todo["uuid"] in self.state["things_to_todoist"]:
-                LOG.debug("Todo %s (\"%s\") synced already",
-                          todo["uuid"], todo["title"])
-                continue
-
-            if self.dry_run:
-                LOG.info("[dry-run] Would create ToDoist todo '%s' in the"
-                         " inbox", todo["title"])
-                self._dry_run_things_parents.add(todo["uuid"])
-                continue
-
-            new_todo = self.todoist.create_todo(todo["title"], inbox_id)
-            todoist_id = str(new_todo.id)
-            self.state["todoist_to_things"][todoist_id] = todo["uuid"]
-            self.state["things_to_todoist"][todo["uuid"]] = todoist_id
-
-        # Done after the loop above so that checklists hanging off todos
-        # created by this very run have a Todoist parent to go under.
-        self.sync_things_subtasks_to_todoist(things_todos, closed_in_todoist)
-
-        # TODO better return
-        return self.state
 
     def sync_things_subtasks_to_todoist(self, things_todos, closed_in_todoist):
         """
@@ -204,7 +343,7 @@ class ToThingist(object):
 
     def sync_todoist_to_things(self, tag_import=False):
 
-        """Sync todoist inbox todos into a given Things location.
+        """Sync each mapped todoist project into its Things location.
 
          Args:
           tag_import: tag all imported todos with "todoist_sync"
@@ -213,56 +352,32 @@ class ToThingist(object):
 
         tags = ["todoist_sync"] if tag_import else []
 
-        todoist_todos = self.todoist.get_all_todos(self.todoist.get_inbox_id())
+        for pair in self.pairs:
+            project_id = self.todoist_project_id(pair)
 
-        for todoist_todo in todoist_todos:
-            # This list will include subtasks - we cover those later
-            # so ignore for now
-            if todoist_todo.parent_id:
-                continue
+            # Whether Todoist has a todo completed is taken from the
+            # endpoint it came out of rather than from the todo itself
+            todoist_todos = self.todoist.get_uncompleted_todos(project_id)
+            completed_todos = self.completed_todoist_todos(project_id)
 
-            name = todoist_todo.content
-            todoist_id = str(todoist_todo.id)
+            # Both lists include subtasks - we cover those below, so
+            # ignore them for now
+            for todo in todoist_todos:
+                if not todo.parent_id:
+                    self.import_todo(pair, todo, tags=tags, completed=False)
+            for todo in completed_todos:
+                if not todo.parent_id:
+                    self.import_todo(pair, todo, tags=tags, completed=True)
 
-            if todoist_id in self.state["todoist_to_things"]:
-                LOG.debug("Todo %s (\"%s\") synced already", todoist_id, name)
+            self.sync_todoist_subtasks_to_things(
+                pair, todoist_todos + completed_todos)
 
-                things_id = self.state["todoist_to_things"][todoist_id]
-                if (todoist_todo.is_completed and
-                        things_id not in self.closed_things_ids()):
-                    # todo is complete, complete locally
-                    if self.dry_run:
-                        LOG.info("[dry-run] Would mark '%s' as complete in"
-                                 " Things", name)
-                    else:
-                        self.things.set_complete(things_id)
-                        LOG.info("Marked '%s' as complete", name)
-
-                continue
-
-            if not todoist_todo.is_completed:
-                if self.dry_run:
-                    LOG.info("[dry-run] Would create Things todo '%s' in %s",
-                             name, self.things_location)
-                    self._dry_run_todoist_parents.add(todoist_id)
-                    continue
-
-                things_id = self.things.create_todo(
-                    name, self.things_location, tags=tags)
-                if not things_id:
-                    # The todo exists in Things but we have no ID to
-                    # record for it. create_todo() has said as much.
-                    continue
-
-                self.state["todoist_to_things"][todoist_id] = things_id
-                self.state["things_to_todoist"][things_id] = todoist_id
-
-        self.sync_todoist_subtasks_to_things(todoist_todos)
+        self._warn_about_unclosable_items()
 
         # TODO better return
         return self.state
 
-    def sync_todoist_subtasks_to_things(self, todoist_todos):
+    def sync_todoist_subtasks_to_things(self, pair, todoist_todos):
         """
         Sync Todoist subtasks into Things todo checklists.
 
@@ -275,10 +390,15 @@ class ToThingist(object):
           with applescript as in pythings but who wants to go back to
           doing that ;_;
 
-         todoist_todos: todos from the Todoist inbox, as returned by
-          ToDoistInterface.get_all_todos().
+         pair: the mapping the todos arrived through.
+         todoist_todos: todos of the mapped Todoist project, completed
+          ones included.
 
         """
+
+        # As in sync_todoist_to_things(), completion is taken from the
+        # endpoint a todo came out of rather than from the todo itself.
+        completed_ids = self.completed_todoist_ids()
 
         subtasks_by_parent = self.todoist.get_subtasks(todoist_todos)
 
@@ -293,11 +413,11 @@ class ToThingist(object):
                         ", ".join("'%s'" % task.content for task in subtasks))
                 elif parent_id in self._dry_run_todoist_parents:
                     for subtask in subtasks:
-                        if not subtask.is_completed:
+                        if str(subtask.id) not in completed_ids:
                             LOG.info(
                                 "[dry-run] Would add checklist item '%s' to a"
-                                " Things todo in %s",
-                                subtask.content, self.things_location)
+                                " Things todo in '%s'",
+                                subtask.content, pair.things_location)
                 # Otherwise we haven't seen a parent at all
                 continue
 
@@ -310,7 +430,7 @@ class ToThingist(object):
                     subtask_id)
 
                 if item_uuid:
-                    if not subtask.is_completed:
+                    if subtask_id not in completed_ids:
                         continue
 
                     # Reading the checklist is only worth it once it is
@@ -322,12 +442,13 @@ class ToThingist(object):
                         self._unclosable_checklist_items.append(name)
                     continue
 
-                if subtask.is_completed:
+                if subtask_id in completed_ids:
                     continue
 
                 if self.dry_run:
                     LOG.info("[dry-run] Would add checklist item '%s' to a"
-                             " Things todo in %s", name, self.things_location)
+                             " Things todo in '%s'", name,
+                             pair.things_location)
                     continue
 
                 item_uuid = self.things.create_checklist_item(
@@ -341,8 +462,6 @@ class ToThingist(object):
                     item_uuid
                 self.state["things_to_todoist_subtasks"][item_uuid] = \
                     subtask_id
-
-        self._warn_about_unclosable_items()
 
     def closed_checklist_items(self, things_uuid):
         """Return the IDs of a Things todo's checklist items that are done."""
@@ -371,6 +490,53 @@ class ToThingist(object):
             ", ".join("'%s'" % name
                       for name in self._unclosable_checklist_items))
         self._unclosable_checklist_items = []
+
+    def import_todo(self, pair, todoist_todo, tags=(), completed=False):
+        """
+        Import a todoist todo to a things location
+
+         pair: the mapping the todo arrived through.
+         todoist_todo: the todo to import.
+         tags: tags to apply to a todo created in Things.
+         completed: whether ToDoist has this todo completed.
+        """
+
+        name = todoist_todo.content
+        todoist_id = str(todoist_todo.id)
+
+        if todoist_id in self.state["todoist_to_things"]:
+            LOG.debug("Todo %s (\"%s\") synced already", todoist_id, name)
+
+            things_id = self.state["todoist_to_things"][todoist_id]
+            if completed and things_id not in self.closed_things_ids():
+                # todo is complete, complete locally
+                if self.dry_run:
+                    LOG.info("[dry-run] Would mark '%s' as complete in"
+                             " Things", name)
+                else:
+                    self.things.set_complete(things_id)
+                    LOG.info("Marked '%s' as complete", name)
+
+            return
+
+        if completed:
+            return
+
+        if self.dry_run:
+            LOG.info("[dry-run] Would create Things todo '%s' in '%s'",
+                     name, pair.things_location)
+            self._dry_run_todoist_parents.add(todoist_id)
+            return
+
+        things_id = self.things.create_todo(
+            name, pair.things_location, tags=tags)
+        if not things_id:
+            # The todo exists in Things but we have no ID to record for
+            # it. create_todo() has said as much.
+            return
+
+        self.state["todoist_to_things"][todoist_id] = things_id
+        self.state["things_to_todoist"][things_id] = todoist_id
 
 
 def read_state(statefile):
@@ -452,29 +618,43 @@ def main():
         format="%(message)s")
 
     config = configparser.ConfigParser()
+    # Option names in [projects] are Todoist project names, which are
+    # case sensitive. get_option() keeps the case of the other option
+    # names from mattering.
+    config.optionxform = str
     if not config.read(os.path.expanduser(options.configpath)):
         sys.exit("No configuration file found at %s" % options.configpath)
 
     try:
-        api_key = config.get("login", "api_token")
-        statefile = os.path.expanduser(config.get("config", "statefile"))
-        things_location = config.get("config", "thingslocation")
-    except (configparser.NoSectionError, configparser.NoOptionError) as exc:
-        sys.exit(
-            "Incomplete configuration in %s: %s" % (options.configpath, exc)
-        )
+        api_key = get_option(config, "login", "api_token")
+        statefile = os.path.expanduser(get_option(config, "config",
+                                                 "statefile"))
+        pairs = read_pairs(config)
+    except (configparser.Error, ValueError) as e:
+        sys.exit("Bad configuration in %s: %s" % (options.configpath, e))
+
+    if (config.has_section(MAPPING_SECTION) and
+            get_option(config, "config", "thingslocation")):
+        LOG.info("Ignoring 'thingslocation' as the [%s] section says what to"
+                 " sync where", MAPPING_SECTION)
 
     # Optional: things.py finds the database on its own unless told
     # otherwise (see also the THINGSDB environment variable).
-    things_db = config.get("config", "thingsdb", fallback=None)
+    things_db = get_option(config, "config", "thingsdb")
 
     todoist_obj = todoistinterface.ToDoistInterface(api_key)
     things_obj = thingsinterface.ThingsInterface(filepath=things_db,
                                                  print_sql=options.print_sql)
 
-    tothingist_obj = ToThingist(todoist_obj, things_obj, things_location,
+    tothingist_obj = ToThingist(todoist_obj, things_obj, pairs,
                                 read_state(statefile),
                                 dry_run=options.dry_run)
+
+    try:
+        tothingist_obj.check_pairs()
+    except (LookupError, ValueError) as e:
+        sys.exit("Cannot sync the projects configured in %s: %s" % (
+            options.configpath, e))
 
     tothingist_obj.sync_todoist_to_things(tag_import=True)
     tothingist_obj.sync_things_to_todoist()

--- a/todoistinterface.py
+++ b/todoistinterface.py
@@ -10,6 +10,11 @@ from todoist_api_python.api import TodoistAPI
 # Fetch this many days of completed tasks - 90 is current max :/
 COMPLETED_WINDOW_DAYS = 90
 
+# Projects with identical names in different areas use this divider
+PROJECT_PATH_SEPARATOR = "/"
+
+INBOX_NAME = "Inbox"
+
 
 class ToDoistInterface:
     """Ugly wrapper for the ToDoist.com API"""
@@ -17,14 +22,78 @@ class ToDoistInterface:
     def __init__(self, token):
         self.token = token
         self.api = TodoistAPI(token)
+        self._projects = None
 
-    def get_projects(self):
+    def get_projects(self, refresh=False):
         '''
-        Get all projects.
+        Get all projects and store the result.
+
+         refresh: fetch the projects again rather than reusing the ones
+          fetched earlier.
         '''
-        return [project
-                for page in self.api.get_projects()
-                for project in page]
+        if self._projects is None or refresh:
+            self._projects = [project
+                              for page in self.api.get_projects()
+                              for project in page]
+        return self._projects
+
+    def get_project_path(self, project):
+        '''
+        Get the "Parent/Child" path of a project.
+
+         project: a project as returned by get_projects().
+        '''
+        by_id = {each.id: each for each in self.get_projects()}
+
+        names = [project.name]
+        # Projects can't really be their own ancestor, but avoid
+        # endless loops just in case
+        seen = {project.id}
+        parent_id = project.parent_id
+        while parent_id in by_id and parent_id not in seen:
+            seen.add(parent_id)
+            names.append(by_id[parent_id].name)
+            parent_id = by_id[parent_id].parent_id
+
+        return PROJECT_PATH_SEPARATOR.join(reversed(names))
+
+    def resolve_project_id(self, name):
+        '''
+        Get the ID of the project called `name`.
+
+        Raises LookupError if there is no such project, or if the name
+        belongs to more than one of them.
+
+         name: the name of a project, its "Parent/Child" path if the
+          name alone is ambiguous, or "Inbox" for the inbox project
+        '''
+        wanted = name.strip()
+        projects = self.get_projects()
+
+        matches = [project for project in projects
+                   if self.get_project_path(project) == wanted]
+        if not matches:
+            matches = [project for project in projects
+                       if project.name.strip() == wanted]
+        if not matches and wanted.lower() == INBOX_NAME.lower():
+            # The inbox is the one project whose name is not its own -
+            # it is named for the language the account is set up in.
+            return self.get_inbox_id()
+
+        if len(matches) == 1:
+            return matches[0].id
+
+        if not matches:
+            raise LookupError(
+                "No Todoist project called %r (this account has %s)" % (
+                    name, ", ".join(sorted(self.get_project_path(project)
+                                           for project in projects))))
+
+        raise LookupError(
+            "%d Todoist projects are called %r - name one of %s instead" % (
+                len(matches), name,
+                ", ".join(sorted(self.get_project_path(project)
+                                 for project in matches))))
 
     def get_uncompleted_todos(self, project_id):
         '''
@@ -37,11 +106,16 @@ class ToDoistInterface:
                 for page in self.api.get_tasks(project_id=project_id)
                 for task in page]
 
-    def get_completed_todos(self, project_id):
+    def get_completed_todos(self, project_id=None):
         '''
-        Get as many completed todo items in a project as possible.
+        Get as many completed todo items as possible.
 
         API limitations mean that we cannot get all completed items
+
+         project_id: only return the completed todos of this project.
+          The endpoint has no project parameter, so asking for one
+          project costs the same as asking for all of them - callers
+          syncing several projects want to filter one fetch themselves.
         '''
         until = datetime.datetime.now(datetime.timezone.utc)
         since = until - datetime.timedelta(days=COMPLETED_WINDOW_DAYS)
@@ -51,7 +125,7 @@ class ToDoistInterface:
                 for page in self.api.get_completed_tasks_by_completion_date(
                     since=since, until=until)
                 for task in page
-                if task.project_id == project_id]
+                if project_id is None or task.project_id == project_id]
 
     def get_all_todos(self, project_id):
         '''
@@ -119,13 +193,19 @@ class ToDoistInterface:
 
 
 def main():
+    import argparse
+    import pprint
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project", nargs="?", default=INBOX_NAME,
+                        help="Todoist project to dump")
+    options = parser.parse_args()
+
     config = configparser.ConfigParser()
     config.read(os.path.expanduser("~/.tothingist"))
     api_key = config.get('login', 'api_token')
     api = ToDoistInterface(api_key)
-    inbox_id = api.get_inbox_id()
-    import pprint
-    pprint.pprint(api.get_all_todos(inbox_id))
+    pprint.pprint(api.get_all_todos(api.resolve_project_id(options.project)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the ability to map between any number of projects.

Deprecate the default of `thingslocation`, use a project-to-project mapping by default.